### PR TITLE
Switch out SED postbuild script for Vite alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "scripts": {
     "build": "react-router build",
-    "postbuild": "sed -i.bak 's/\"react-dom\\/server\"/\"react-dom\\/server.node\"/' build/server/index.js && rm -f build/server/index.js.bak",
     "dev": "bunx --bun vite",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "bun run server.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,4 +18,9 @@ export default defineConfig({
       injectClientScript: false
     })
   ],
+  resolve: {
+		alias: {
+			'react-dom/server': 'react-dom/server.node',
+		},
+	},
 });


### PR DESCRIPTION
As someone who doesn't have SED installed generally, seems an easier solution is to just let Vite handle the alias.

Let me know if there's a reason this doesn't work for you 👀